### PR TITLE
ENH: update to patched ads module to use motion lib

### DIFF
--- a/configure/RELEASE
+++ b/configure/RELEASE
@@ -11,7 +11,7 @@ IOCADMIN_MODULE_VERSION   = R3.1.15-1.10.0
 ASYN_MODULE_VERSION       = R4.35-0.0.1
 MOTOR_MODULE_VERSION      = R6.9-ess-0.0.1
 ETHERCATMC_MODULE_VERSION = R2.1.0-0.1.0
-ADS_MODULE_VERSION        = R2.0.0-0.0.2
+ADS_MODULE_VERSION        = R2.0.0-0.0.3
 
 
 # ============================================================


### PR DESCRIPTION
I did a one-line fix in the ads module to allow it to work with `tc_mca_stdlib` installed as a library. I'll show details if interested.